### PR TITLE
Upgrade to Elasticsearch 7.16.1

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -30,43 +30,43 @@ kubectl apply -f ./elastic-certificates-secret.yml
 
 ### Deploy Elasticsearch
 
-Deploy a single node Elasticsearch 7.15.0 with authentication, certificates for TLS and custom [values](./values-elasticsearch.yml):
+Deploy a single node Elasticsearch with authentication, certificates for TLS and custom [values](./values-elasticsearch.yml):
 
 ```
 helm upgrade --install elasticsearch \
   elastic/elasticsearch \
   --namespace logging \
-  --version "7.15.0" \
+  --version "7.16.1" \
   --values ./values-elasticsearch.yml
 ```
 
 ## Deploy Kibana using Helm
 
-Deploy Kibana 7.15.0 using authentication and TLS to connect to Elasticsearch (see [values](./values-kibana.yml)):
+Deploy Kibana using authentication and TLS to connect to Elasticsearch (see [values](./values-kibana.yml)):
 
 ```
 helm upgrade --install kibana \
   elastic/kibana \
   --namespace logging \
-  --version "7.15.0" \
+  --version "7.16.1" \
   --values ./values-kibana.yml
 ```
 
 ## Deploy Filebeat using Helm
 
-Deploy Filebeat 7.15.0 using authentication and TLS to connect to Elasticsearch (see [values](./values-filebeat.yml)).
+Deploy Filebeat using authentication and TLS to connect to Elasticsearch (see [values](./values-filebeat.yml)).
 
 ```
 helm upgrade --install filebeat \
   elastic/filebeat \
   --namespace logging \
-  --version "7.15.0" \
+  --version "7.16.1" \
   --values ./values-filebeat.yml
 ```
 
 # Essential Reading
 
-https://www.elastic.co/guide/en/elasticsearch/reference/7.15/configuring-stack-security.html
+https://www.elastic.co/guide/en/elasticsearch/reference/7.16/configuring-stack-security.html
 
-https://www.elastic.co/guide/en/elasticsearch/reference/7.15/security-settings.html
+https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-settings.html
 

--- a/logging/install-elastic-stack.sh
+++ b/logging/install-elastic-stack.sh
@@ -3,7 +3,7 @@ set -eu
 
 # See https://github.com/lisenet/kubernetes-homelab
 
-STACK_VERSION="7.15.0"
+STACK_VERSION="7.16.1"
 NAMESPACE="logging"
 
 if ! kubectl get ns logging > /dev/null; then
@@ -30,13 +30,17 @@ else
   printf "%s\\n" "Helm repository for 'elastic  already exists"
 fi
 
+helm repo update
+
 if [ -e ./values-elasticsearch.yml ]; then
   printf "\\n%s\\n" "Deploying Elasticsearch"
   helm upgrade --install elasticsearch \
     elastic/elasticsearch \
     --namespace "${NAMESPACE}" \
     --version "${STACK_VERSION}" \
-    --values ./values-elasticsearch.yml
+    --values ./values-elasticsearch.yml \
+    --set service.type="LoadBalancer" \
+    --set service.LoadBalancerIP="10.11.1.59"
 else
   printf "%s\\n" "Helm values file for Elasticsearch not found"
   exit 1
@@ -48,7 +52,9 @@ if [ -e ./values-kibana.yml ]; then
     elastic/kibana \
     --namespace "${NAMESPACE}" \
     --version "${STACK_VERSION}" \
-    --values ./values-kibana.yml
+    --values ./values-kibana.yml \
+    --set service.type="LoadBalancer" \
+    --set service.LoadBalancerIP="10.11.1.58"
 else
   printf "%s\\n" "Helm values file for Kibana not found"
   exit 1


### PR DESCRIPTION
Upgrade to Elasticsearch 7.16.1 in order to mitigate the log4j vulnerability by setting the JVM option -Dlog4j2.formatMsgNoLookups=true and remove the vulnerable JndiLookup class from the log4j package.